### PR TITLE
✨ Configurable IV Length, Tag and AAD

### DIFF
--- a/.license_report.md
+++ b/.license_report.md
@@ -2,4 +2,4 @@
 This report lists direct dependencies (async) and their matched licenses.
 
 - **aes-gcm** (version: `0.10.3`) → *Apache-2.0 OR MIT*
-- **thiserror** (version: `1.0.69`) → *MIT OR Apache-2.0*
+- **thiserror** (version: `2.0.16`) → *MIT OR Apache-2.0*

--- a/README.md
+++ b/README.md
@@ -40,8 +40,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // use a stable key.
     let key = lockboxer::generate_key();
 
-    // Initialize a vault with the key and a tag
-    let vault = Vault::new(&key, "AES.GCM.V1");
+    // Initialize a vault with the key
+    let vault = Vault::new(&key);
+
+    // Or with config options:
+    let vault = Vault::new(&key)
+        .with_tag("Custom.Tag.V1")
+        .with_aad("Custom.AAD");
 
     // Encrypt some plaintext
     let plaintext = b"Hello, secure world!";

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,7 +2,7 @@ use lockboxer::Vault;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let key = lockboxer::generate_key();
-    let vault = Vault::new(&key, "AES.GCM.V1");
+    let vault = Vault::new(&key);
 
     let plaintext = b"plaintext";
     println!("Plaintext: {}", std::str::from_utf8(plaintext)?);

--- a/examples/config.rs
+++ b/examples/config.rs
@@ -1,0 +1,23 @@
+use lockboxer::{IvLength16, VaultWithConfig};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let key = lockboxer::generate_key();
+    let vault: VaultWithConfig<IvLength16> = VaultWithConfig::new(&key)
+        .with_tag("Custom.Tag.V1")
+        .with_aad("Custom.AAD");
+
+    let plaintext = b"plaintext";
+    println!("Plaintext: {}", std::str::from_utf8(plaintext)?);
+
+    // Encrypt the plaintext
+    let encrypted = vault.encrypt(plaintext)?;
+    println!("Encrypted: {}", hex::encode_upper(&encrypted));
+
+    // Decrypt the ciphertext
+    let decrypted = vault.decrypt(&encrypted)?;
+    println!("Decrypted: {}", decrypted);
+
+    assert_eq!(&decrypted.as_bytes(), plaintext);
+
+    Ok(())
+}

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -1,0 +1,70 @@
+use aes_gcm::aead::consts::U16;
+use aes_gcm::aead::rand_core::RngCore;
+use aes_gcm::aead::{Aead, KeyInit, OsRng, Payload};
+use aes_gcm::aes::Aes256;
+use aes_gcm::{Aes256Gcm, AesGcm, Error, Key, Nonce};
+
+pub type Aes256GcmIv16 = AesGcm<Aes256, U16>;
+
+pub trait IvLength: KeyInit + Aead {
+    fn iv_length() -> usize;
+}
+
+impl IvLength for Aes256Gcm {
+    fn iv_length() -> usize {
+        12
+    }
+}
+
+impl IvLength for Aes256GcmIv16 {
+    fn iv_length() -> usize {
+        16
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Cipher<I: IvLength> {
+    cipher: I,
+}
+
+impl<I: IvLength> Cipher<I> {
+    pub(crate) fn new(key: &[u8]) -> Self {
+        let key = Key::<I>::from_slice(key);
+
+        Cipher {
+            cipher: I::new(key),
+        }
+    }
+
+    pub(crate) fn init_iv(&self) -> Vec<u8> {
+        let mut iv = vec![0u8; I::iv_length()];
+        OsRng.fill_bytes(&mut iv);
+        iv
+    }
+
+    pub(crate) fn encrypt(&self, payload: Payload, iv: Vec<u8>) -> Result<Vec<u8>, Error> {
+        let nonce = Nonce::from_slice(&iv);
+        self.cipher.encrypt(nonce, payload)
+    }
+
+    pub(crate) fn decrypt(&self, remainder: Vec<u8>, aad: &[u8]) -> Result<Vec<u8>, Error> {
+        let iv_length = I::iv_length();
+
+        // Extract IV, Ciphertag, and Ciphertext
+        let iv = &remainder[..iv_length];
+        let ciphertag = &remainder[iv_length..iv_length + 16]; // 16-byte Ciphertag
+        let ciphertext = &remainder[iv_length + 16..]; // Remaining is ciphertext
+
+        // Combine ciphertext and ciphertag for decryption
+        let mut combined_ciphertext = Vec::new();
+        combined_ciphertext.extend_from_slice(ciphertext);
+        combined_ciphertext.extend_from_slice(ciphertag); // Append the tag for decryption
+
+        let payload = Payload {
+            msg: &combined_ciphertext,
+            aad,
+        };
+
+        self.cipher.decrypt(Nonce::from_slice(iv), payload)
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,24 @@
+pub(crate) const DEFAULT_TAG: &str = "AES.GCM.V1";
+pub(crate) const DEFAULT_AAD: &str = "AES256GCM";
+
+/// Configuration for the Vault.
+///
+/// Allows overriding default values for tag and AAD.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VaultConfig {
+    /// A string that represents a version or identifier for the cipher.
+    /// Default is "AES.GCM.V1".
+    pub tag: String,
+    /// Additional Authenticated Data (AAD).
+    /// Default is "AES256GCM".
+    pub aad: String,
+}
+
+impl Default for VaultConfig {
+    fn default() -> Self {
+        Self {
+            tag: DEFAULT_TAG.into(),
+            aad: DEFAULT_AAD.into(),
+        }
+    }
+}


### PR DESCRIPTION
## New Features

### Custom IV Length

```rust
use lockboxer::{IvLength16, VaultWithConfig};

let vault: VaultWithConfig<IvLength16> = VaultWithConfig::new(&key)
```

### Custom Tag and AAD

```rust
use lockboxer::Vault;

let vault = Vault::new(&key)
    .with_tag("Custom.Tag.V1")
    .with_aad("Custom.AAD");
```

## Breaking Changes

### Before

```rust
let vault = Vault::new(&key, "AES.GCM.V1");
```

### After

```rust
let vault = Vault::new(&key);
```
